### PR TITLE
feat(bigquery): add support for google bigquery

### DIFF
--- a/src/adapters/bigquery.js
+++ b/src/adapters/bigquery.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-disable no-use-before-define, no-underscore-dangle */
+function conjunction(predicates, type) {
+  const expressions = predicates
+    .map(getFilterExpression)
+    .filter((e) => !!e);
+
+  if (expressions.length > 1) {
+    return `(${expressions.join(` ${type} `)})`;
+  }
+  return expressions.join('');
+}
+
+const filters = {
+  or: (qbtree) => conjunction(qbtree.predicates, 'OR'),
+
+  and: (qbtree) => conjunction(qbtree.predicates, 'AND'),
+
+  property: ({ property, value, operation = 'equals' }) => {
+    switch (operation) {
+      case 'equals': return `${property} = "${value}"`;
+      case 'not': return `${property} != "${value}"`;
+      default: return 'TRUE';
+    }
+  },
+
+  rangeproperty: ({
+    rangeproperty, lowerBound, upperBound, lowerOperation = '>', upperOperation = '<',
+  }) => {
+    if (Number.isFinite(lowerBound) && Number.isFinite(upperBound)) {
+      return `(${rangeproperty} ${lowerOperation} ${lowerBound} AND ${rangeproperty} ${upperOperation} ${upperBound})`;
+    } else if (Number.isFinite(lowerBound)) {
+      return `${rangeproperty} ${lowerOperation} ${lowerBound}`;
+    } else if (Number.isFinite(upperBound)) {
+      return `${rangeproperty} ${upperOperation} ${upperBound}`;
+    }
+    return 'TRUE';
+  },
+};
+
+function defaultfilter() {
+  return 'TRUE';
+}
+
+function getFilterExpression(qbtree) {
+  // look up a function for the type
+  const applicable = filters[qbtree._type] ? filters[qbtree._type] : defaultfilter;
+  const filterexp = applicable(qbtree);
+
+  return filterexp;
+}
+
+export function adapt(qbtree) {
+  const prefix = 'SELECT * FROM (';
+  const suffix = [
+    ')',
+    `WHERE ${getFilterExpression(qbtree)}`,
+  ];
+
+  if (Number.isInteger(qbtree.limit)) {
+    suffix.push(`LIMIT ${qbtree.limit}`);
+    if (Number.isInteger(qbtree.offset)) {
+      suffix.push(`OFFSET ${qbtree.offset}`);
+    }
+  }
+
+  return [prefix, suffix.join('\n')];
+}

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { load as loadquerystring } from './loaders/url.js';
 import { load as loadtext } from './loaders/text.js';
 import { load as loadjson } from './loaders/json.js';
 import { adapt as createfilter } from './adapters/filter.js';
+import { adapt as bigquery } from './adapters/bigquery.js';
 import { adapt as algolia } from './adapters/algolia.js';
 
 /**
@@ -42,6 +43,7 @@ const filter = (strings) => createfilter(load(strings));
 
 const qb = {
   filter,
+  bigquery: (i) => bigquery(load(i)),
   algolia: (i) => algolia(load(i)),
 };
 

--- a/test/bigquery.test.js
+++ b/test/bigquery.test.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+import assert from 'assert';
+import { safeLoad } from 'js-yaml';
+import { qb } from '../src/index.js';
+
+function assertQuery(yaml, expectedQuery) {
+  const [prefix, suffix] = qb.bigquery(safeLoad(yaml));
+  assert.equal(`${prefix}SELECT * FROM visits${suffix}`, expectedQuery);
+}
+
+describe('BigQuery tests', () => {
+  it('Null query works', () => {
+    assertQuery('', `SELECT * FROM (SELECT * FROM visits)
+WHERE TRUE`);
+  });
+
+  it('Simple query works', () => {
+    assertQuery(`
+property:
+    _: foo
+    value: bar
+p:
+  limit: 10
+  offset: 20
+`, `SELECT * FROM (SELECT * FROM visits)
+WHERE foo = "bar"
+LIMIT 10
+OFFSET 20`);
+  });
+
+  it('Invalid query works', () => {
+    assertQuery(`
+and:
+  - property:
+      _: foo
+      value: bar
+      operation: unsupported
+  - rangeproperty:
+      _: baz
+p:
+  limit: 10
+`, `SELECT * FROM (SELECT * FROM visits)
+WHERE (TRUE AND TRUE)
+LIMIT 10`);
+  });
+
+  it('Range query works with TO', () => {
+    assertQuery(`
+and:
+  - property:
+      _: foo
+      value: bar
+      operation: not
+  - rangeproperty:
+      _: baz
+      lowerBound: 0
+      upperBound: 100
+      lowerOperation: ">="
+      upperOperation: "<="
+p:
+  limit: 10
+  offset: 20
+`, `SELECT * FROM (SELECT * FROM visits)
+WHERE (foo != "bar" AND (baz >= 0 AND baz <= 100))
+LIMIT 10
+OFFSET 20`);
+  });
+
+  it('Range query works', () => {
+    assertQuery(`
+and:
+  - property:
+      _: foo
+      value: bar
+  - rangeproperty:
+      _: baz
+      lowerBound: 0
+      upperBound: 100
+p:
+  limit: 10
+  offset: 20
+`, `SELECT * FROM (SELECT * FROM visits)
+WHERE (foo = "bar" AND (baz > 0 AND baz < 100))
+LIMIT 10
+OFFSET 20`);
+  });
+
+  it('OR works', () => {
+    assertQuery(`
+or:
+  - rangeproperty:
+      _: foo
+      lowerBound: 0
+  - rangeproperty:
+      _: baz
+      upperBound: 100
+p:
+  limit: 10
+  offset: 20
+`, `SELECT * FROM (SELECT * FROM visits)
+WHERE (foo > 0 OR baz < 100)
+LIMIT 10
+OFFSET 20`);
+  });
+});


### PR DESCRIPTION
The bigquery adapter returns a pair of prefix and suffix to embed an existing bigquery query in (as a subselect). The inner query should return the entire unfiltered domain model, the querybuilder-generated outer query will filter, limit, and restrict the result set

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
